### PR TITLE
v0.0.1_KOSPI 종목코드 전처리 및 적재 

### DIFF
--- a/airflow/dags/get_kospi_code.py
+++ b/airflow/dags/get_kospi_code.py
@@ -1,0 +1,95 @@
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.bash import BashOperator
+from airflow.models.variable import Variable
+from datetime import datetime
+
+default_args = {
+	'owner': 'v0.0.1/gazuaa',
+	'depends_on_past' : False,
+	'start_date': datetime(2023,1,1),
+}
+
+dag = DAG('kind_dag', default_args = default_args, schedule_interval = '@once')
+
+def fetch_kospi_code():
+	import pandas as pd
+	url = 'https://kind.krx.co.kr/corpgeneral/corpList.do'
+	kospi_code = pd.read_html(url + "?method=download&marketType=stockMkt")[0]
+	kospi_code = kospi_code[['회사명', '종목코드']]
+
+	return kospi_code
+
+def convert_kospi_code(x):
+	tmp_data = str(x)
+	return '0' * (6-len(tmp_data)) + tmp_data + '.KS'
+	
+
+def apply_kospi_code(**context):
+	convert_code = context['ti'].xcom_pull(task_ids='get_tmpKospi_code')
+	convert_code['종목코드'] = convert_code['종목코드'].apply(convert_kospi_code)
+	return convert_code
+
+def load_kospi_code(**context):
+	import mysql.connector
+
+	final_data = context['ti'].xcom_pull(task_ids='convert_code')
+	conn = mysql.connector.connect(user='stock', password= '1234', host='192.168.90.128', database = 'stock', port = '3306', auth_plugin='mysql_native_password')
+	print(final_data)
+	cursor = conn.cursor()
+
+	for index, row in final_data.iterrows():
+
+		company_name = row['회사명']
+		company_code = row['종목코드']
+		
+		values = (company_name, company_code)
+		print(values)
+		
+		query = "INSERT INTO kospi_code (company_name, company_code) VALUES (\"%s\", \"%s\")" %(values[0], values[1])
+		print(query)
+		#cursor.execute(query, values)
+		#conn.commit()
+	conn.close()
+
+
+first = EmptyOperator(
+	task_id = 'start',
+	dag = dag
+)
+
+start_noti = BashOperator(
+	task_id = 'start_noti',
+	bash_command = """
+		curl -X POST -H 'Authorization: Bearer {{var.value.BEARER_TOKEN_YODA}}' \
+		-F 'message= \n DAG이름 : {{dag.dag_id}} 시작!' \
+		https://notify-api.line.me/api/notify
+	""",
+	dag = dag
+)
+
+get_rawCode = PythonOperator(
+	task_id = 'get_tmpKospi_code',
+	python_callable = fetch_kospi_code,
+	dag = dag
+)
+
+convert_tmpCode = PythonOperator(
+	task_id = 'convert_code',
+	python_callable = apply_kospi_code,
+	dag = dag
+)
+
+load_code = PythonOperator(
+	task_id = 'load_kospi_code',
+	python_callable = load_kospi_code,
+	dag = dag
+)
+
+finish = EmptyOperator(
+	task_id = 'finish',
+	dag = dag
+)
+
+first >> start_noti >> get_rawCode >> convert_tmpCode >> load_code >> finish 


### PR DESCRIPTION
## KSP 종목코드 전처리 및 적재

<h5>요구 사항</h5>

- [x] yfinance에서 쓸수 있는 국제 표준인 ticker number로 치환하기
- [x] line noti로 dag시작과 종료를 알리기
- [x] 치환된 최종 데이터를 db에 적재 [ DB: stock, TABLE: kospi_code ]

---

<h5>결과</h5>

<img width="1200" alt="Screen Shot 2023-06-08 at 3 39 40 PM" src="https://github.com/dduck-sang/gazuaa/assets/23203791/a77faebf-3ff0-4d7e-8ed1-9ec130746134">


1. kind.co.kr 정부 사이트에서 KOSPI 종목 번호를 수집
2. KOSPI 종목번호를 6자리로 치환
3. 치환한 데이터 뒤에 ticker number에 맞게 시장 코드를 부여
4. mysql 적재

---

<h5>개선점</h5>

- mysql execute시, db의 연결 부하를 막기위해, insertmany를 통해, 버퍼에 올린뒤 한꺼번에 db에 밀어넣기
- line_noti를 사용하여 시작과 종료 알림을 보내는데, 이에 operator를 frame을 찍어내 operator build

