### PR TITLE
v0.0.2_KOSDAQ 종목코드 전처리 및 적재

### DIFF
--- a/airflow/dags/get_kosdaq_code.py
+++ b/airflow/dags/get_kosdaq_code.py
@@ -5,6 +5,7 @@ from airflow.operators.bash import BashOperator
 from airflow.models.variable import Variable
 from datetime import datetime
 
+
 default_args = {
 	'owner' : 'v0.0.2/gazuaa',
 	'depends_on_past' : False,


### PR DESCRIPTION
## KSQ 종목코드 전처리 및 적재

<h5>요구 사항</h5>

- [x] yfinance에서 쓸수 있는 국제 표준인 ticker number로 치환하기
- [x] line noti로 dag시작과 종료를 알리기
- [x] 치환된 최종 데이터를 db에 적재 [ DB: stock, TABLE: kospi_code ]
- [x]  치환된 최종 데이터를 hadoop server로 적재
- [x] v0.0.1 개선점인 line_noti func를 callable 하게  build
- [x] XCOM을 사용하지 않고, operator간 종속성 제거

---

<h5>결과</h5>

<img width="1146" alt="Screen Shot 2023-06-08 at 4 01 39 PM" src="https://github.com/dduck-sang/gazuaa/assets/23203791/522c2748-4901-4574-8a20-7735fe32118e">


1. kind.co.kr 정부 사이트에서 KOSPI 종목 번호를 수집
2. KOSPI 종목번호를 6자리로 치환
3. 치환한 데이터 뒤에 ticker number에 맞게 시장 코드를 부여
4. mysql 적재
5. hadoop server에 data 적재
---

<h5>개선점</h5>

- mysql execute시, db의 연결 부하를 막기위해, insertmany를 통해, 버퍼에 올린뒤 한꺼번에 db에 밀어넣기
- airflow는 core_engine이 아니라, data_pipeline을 만드는 코디네이터이니, 실제 처리 코드는 spark나, hive 등으로 빼고 일만 시키기
